### PR TITLE
chore: update dependencies

### DIFF
--- a/main/platformio.ini
+++ b/main/platformio.ini
@@ -12,4 +12,7 @@
 platform = espressif32
 board = upesy_wrover
 framework = arduino
-lib_deps = adafruit/Adafruit TCS34725 @ ^2.2.1
+
+lib_deps = 
+    adafruit/Adafruit TCS34725@^1.4.4
+    https://github.com/makerviet/Arduino-PS2X-ESP32-Makerbot


### PR DESCRIPTION
update Adafruit TCS34725 library to version 1.4.4 and add Arduino-PS2X-ESP32-Makerbot dependency